### PR TITLE
Potential fix for code scanning alert no. 2: Use of externally-controlled format string

### DIFF
--- a/components/website/expand-website.tsx
+++ b/components/website/expand-website.tsx
@@ -263,7 +263,7 @@ const ExpandWebsite = (props: {
       const url = cleanupUrl(websiteId);
       const w = props.websiteCache[url];
       if (!w) {
-        console.error(url, 'Unable to find website for url');
+        console.error('Unable to find website for url: %s', url);
       }
       setWebsite(w);
 


### PR DESCRIPTION
Potential fix for [https://github.com/zamiang/kelp/security/code-scanning/2](https://github.com/zamiang/kelp/security/code-scanning/2)

To fix this problem, we should avoid passing user-controlled data as the format string (the first argument) to `console.error`. Instead, we should use a constant string as the first argument, and pass the user-controlled value as a subsequent argument, ideally using a format specifier like `%s` to ensure the value is treated as a string. This prevents any format specifiers in the user input from being interpreted by the logging function. Specifically, in `components/website/expand-website.tsx`, line 266 should be changed from `console.error(url, 'Unable to find website for url');` to `console.error('Unable to find website for url: %s', url);`. No new imports or methods are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
