### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL substring sanitization

### DIFF
--- a/components/fetch/google/fetch-calendar-events.ts
+++ b/components/fetch/google/fetch-calendar-events.ts
@@ -27,10 +27,15 @@ export const getDocumentsFromCalendarEvents = (event: {
   const documentUrls: string[] = [];
   const urls = event.description ? uniq(event.description.match(urlRegex())) : [];
   (urls || []).forEach((url) => {
-    if (url.includes('https://docs.google.com')) {
-      const link = getIdFromLink(url);
-      documentIds.push(link);
-      documentUrls.push(url);
+    try {
+      const parsedUrl = new URL(url);
+      if (parsedUrl.host === 'docs.google.com') {
+        const link = getIdFromLink(url);
+        documentIds.push(link);
+        documentUrls.push(url);
+      }
+    } catch (e) {
+      // Ignore invalid URLs
     }
   });
   (event.attachments || []).map((attachment: gapi.client.calendar.EventAttachment) => {


### PR DESCRIPTION
Potential fix for [https://github.com/zamiang/kelp/security/code-scanning/3](https://github.com/zamiang/kelp/security/code-scanning/3)

To fix the problem, the code should parse the URL and check the host explicitly, rather than using a substring check. The best way is to use the standard `URL` class (available in modern JavaScript/TypeScript environments) to parse the URL and then check if the host is exactly `docs.google.com` or matches a whitelist of allowed hosts. This change should be made in the `getDocumentsFromCalendarEvents` function, specifically in the loop where URLs are filtered. No new dependencies are needed, as the `URL` class is built-in.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
