### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete URL substring sanitization

### DIFF
--- a/components/fetch/google/fetch-calendar-events.ts
+++ b/components/fetch/google/fetch-calendar-events.ts
@@ -6,6 +6,13 @@ import { formatGmailAddress } from '../../fetch/google/fetch-people';
 import { ISegment, attendee, responseStatus, segmentState } from '../../store/data-types';
 import { getIdFromLink } from '../../store/models/document-model';
 
+
+function isAllowedHost(host: string, allowedDomains: string[]): boolean {
+  return allowedDomains.some(domain =>
+    host === domain || host.endsWith('.' + domain)
+  );
+}
+
 const getStateForMeeting = (event: gapi.client.calendar.Event): segmentState => {
   const currentTime = new Date();
   if (!event.end || !event.start) {
@@ -50,7 +57,17 @@ const getVideoLinkFromCalendarEvent = (event: gapi.client.calendar.Event) => {
     : [];
   return first(
     meetingDescriptionLinks?.filter(
-      (link) => link.includes('zoom.us') || link.includes('webex.com'),
+      (link) => {
+        try {
+          const urlObj = new URL(link);
+          return (
+            isAllowedHost(urlObj.host, ['zoom.us', 'webex.com'])
+          );
+        } catch (e) {
+          // If URL parsing fails, skip this link
+          return false;
+        }
+      },
     ),
   );
 };


### PR DESCRIPTION
Potential fix for [https://github.com/zamiang/kelp/security/code-scanning/4](https://github.com/zamiang/kelp/security/code-scanning/4)

To fix the problem, we should parse each URL and check its host component against a whitelist of allowed hosts for Webex and Zoom. Instead of using `link.includes('webex.com')`, we should use the `URL` constructor to parse the link and then check if the host is exactly `webex.com` or ends with `.webex.com` (to allow subdomains). The same logic should be applied for Zoom (`zoom.us`). This change should be made in the `getVideoLinkFromCalendarEvent` function, specifically in the filter on line 53. We need to add a helper function to check if a host matches the allowed domains, and update the filter accordingly. No new imports are needed, as the global `URL` class is available in modern Node.js and browsers.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
