### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Lint
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/zamiang/kelp/security/code-scanning/7](https://github.com/zamiang/kelp/security/code-scanning/7)

To fix the problem, add a `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions to the minimum required. Since the workflow only checks out code and runs local commands (linting, testing, formatting), it only needs read access to the repository contents. The best way to fix this is to add `permissions: contents: read` at the root level of the workflow file, just below the `name` field and above the `on` field. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
