### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete URL substring sanitization

### DIFF
--- a/components/store/models/person-model.ts
+++ b/components/store/models/person-model.ts
@@ -86,7 +86,9 @@ export default class PersonModel {
     // Add email addresses from calendar events
     emailAddresses.forEach((emailAddress) => {
       const formattedEmailAddress = formatGmailAddress(emailAddress);
-      if (formattedEmailAddress.includes('calendar.google.com')) {
+      // Only skip if the domain is exactly 'calendar.google.com'
+      const domain = formattedEmailAddress.split('@')[1];
+      if (domain === 'calendar.google.com') {
         return;
       }
       const personId = emailAddressToPersonIdHash[formattedEmailAddress];


### PR DESCRIPTION
Potential fix for [https://github.com/zamiang/kelp/security/code-scanning/5](https://github.com/zamiang/kelp/security/code-scanning/5)

To fix the problem, we should avoid using a substring check to determine if an email address or URL is associated with `'calendar.google.com'`. Instead, we should parse the input and check the domain (host) part explicitly. If the input is always an email address, we should extract the domain part after the `@` and compare it directly to `'calendar.google.com'`. If the input could be a URL, we should parse the URL and check the host. In this code, since the variable is called `formattedEmailAddress`, it is likely an email address, so we should split on `@` and compare the domain part. The change should be made in the block starting at line 87, replacing the substring check on line 89 with a domain comparison. No new imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
