### PR TITLE
Potential fix for code scanning alert no. 6: Prototype-polluting assignment

### DIFF
--- a/components/website/expand-website.tsx
+++ b/components/website/expand-website.tsx
@@ -299,6 +299,14 @@ const ExpandWebsite = (props: {
     const updatedTags = websiteTags.filter((t) => t !== tag).join(' ');
     await props.store.websiteStore.updateTags(website.id, updatedTags);
 
+    // Prevent prototype pollution
+    if (
+      websiteId === '__proto__' ||
+      websiteId === 'constructor' ||
+      websiteId === 'prototype'
+    ) {
+      throw new Error('Invalid websiteId');
+    }
     (props.websiteCache[websiteId] as any).tags = updatedTags;
     return props.store.incrementLoading();
   };


### PR DESCRIPTION
Potential fix for [https://github.com/zamiang/kelp/security/code-scanning/6](https://github.com/zamiang/kelp/security/code-scanning/6)

To fix the prototype pollution vulnerability, we need to prevent user-controlled keys like `"__proto__"`, `"constructor"`, or `"prototype"` from being used as property names on plain objects. The best way to do this without changing existing functionality is to add a check before assigning to `props.websiteCache[websiteId]`, and refuse to perform the assignment if the key is dangerous. This can be done by adding a guard clause in the `removeTag` function before the assignment on line 302. No new imports are needed, and the change is limited to the `removeTag` function in `components/website/expand-website.tsx`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
